### PR TITLE
feat: adjust concurrency settings and update metrics queries for improved performance

### DIFF
--- a/apps/backend/src/worker.py
+++ b/apps/backend/src/worker.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     argv = [
         'worker',
         '--loglevel=INFO',
-        '--concurrency=15',  # Adjust based on your needs
+        '--concurrency=3',  # Adjust based on your needs
         '-Q', 'default',    # Queue name
     ]
     app.worker_main(argv) 

--- a/infrastructure/deployment/helmfile/values/celery-app-values.yaml
+++ b/infrastructure/deployment/helmfile/values/celery-app-values.yaml
@@ -47,7 +47,7 @@ celery:
           metadata:
             serverAddress: http://prometheus-server.monitoring.svc.cluster.local:80
             threshold: "1"
-            query: ceil(sum(celery_worker_tasks_active{hostname=~".*app-default-worker.*"})/15)
+            query: ceil(sum(celery_worker_tasks_active{hostname=~".*app-default-worker.*"})/3)
     
   flower:
     enabled: true

--- a/infrastructure/deployment/helmfile/values/grafana-values.yaml
+++ b/infrastructure/deployment/helmfile/values/grafana-values.yaml
@@ -1328,7 +1328,7 @@ dashboards:
                     "type": "prometheus",
                     "uid": "Prometheus"
                   },
-                  "expr": "sum(rate(istio_requests_total{destination_workload=~\"inference-balancer-proxy-a|inference-balancer-proxy-b\"}[5m]))",
+                  "expr": "sum(rate(istio_requests_total{destination_workload=~\"inference-balancer-proxy-a|inference-balancer-proxy-b\"}[1m]))",
                   "legendFormat": "Total RPS"
                 }
               ]
@@ -1532,7 +1532,7 @@ dashboards:
                     "type": "prometheus",
                     "uid": "Prometheus"
                   },
-                  "expr": "sum(rate(istio_requests_total{destination_workload=\"inference-balancer-proxy-a\"}[5m]))",
+                  "expr": "sum(rate(istio_requests_total{destination_workload=\"inference-balancer-proxy-a\"}[1m]))",
                   "legendFormat": "Proxy A RPS"
                 },
                 {
@@ -1540,7 +1540,7 @@ dashboards:
                     "type": "prometheus",
                     "uid": "Prometheus"
                   },
-                  "expr": "sum(rate(istio_requests_total{destination_workload=\"inference-balancer-proxy-b\"}[5m]))",
+                  "expr": "sum(rate(istio_requests_total{destination_workload=\"inference-balancer-proxy-b\"}[1m]))",
                   "legendFormat": "Proxy B RPS"
                 }
               ]
@@ -1628,7 +1628,7 @@ dashboards:
                     "type": "prometheus",
                     "uid": "Prometheus"
                   },
-                  "expr": "sum(istio_requests_total{destination_workload=\"inference-balancer-proxy-a\"})",
+                  "expr": "sum(rate(istio_requests_total{destination_workload=\"inference-balancer-proxy-a\"}[1m]))",
                   "legendFormat": "Proxy A Total Requests"
                 },
                 {
@@ -1636,7 +1636,7 @@ dashboards:
                     "type": "prometheus",
                     "uid": "Prometheus"
                   },
-                  "expr": "sum(istio_requests_total{destination_workload=\"inference-balancer-proxy-b\"})",
+                  "expr": "sum(rate(istio_requests_total{destination_workload=\"inference-balancer-proxy-b\"}[1m]))",
                   "legendFormat": "Proxy B Total Requests"
                 }
               ]

--- a/testing/load-testing/kubernetes/deployment.yaml
+++ b/testing/load-testing/kubernetes/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: LOCUST_HOST
           value: "http://celery-app-api"
         - name: LOCUST_USERS
-          value: "1"
+          value: "10"
         - name: LOCUST_SPAWN_RATE
           value: "1"
         - name: LOCUST_RUN_TIME


### PR DESCRIPTION
- Reduced concurrency from 15 to 3 in the worker configuration for better resource management.
- Updated Prometheus queries in Grafana configurations to use a 1-minute rate instead of 5 minutes for more responsive metrics tracking.
- Increased load testing user count from 1 to 10 to better simulate real-world usage scenarios.